### PR TITLE
Correct IR distance unit in docs

### DIFF
--- a/src/sbhs_robomaster/client.py
+++ b/src/sbhs_robomaster/client.py
@@ -349,7 +349,7 @@ class RoboMasterClient:
          - ir_id: The ID of the IR sensor. There appears to be only one IR sensor, so this should always be `1`.
         
         Returns:
-         - The distance in millimetres.
+         - The distance in centimetres.
         """
         return (await self.do("ir_distance_sensor", "distance", ir_id, "?")).get_float(0)
     


### PR DESCRIPTION
It mistakenly says the IR unit is in millimetres, while it is actually in centimetres. I have corrected the docstring to reflect this.